### PR TITLE
Add manifest.json to auto install requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ There are some similar plugins for m1 on the forum(e.g. hassbian). However, I fo
 
 ## How to use it
 
+> If your Home Assistant version is greater than 0.92.0, probably you don't need to manually install `tornado` like below (since this requirement is declared in `manifest.json`).
+
 Install tornado since it rely on tornado.tcpserver:
 
 ```
@@ -46,4 +48,3 @@ The phicomm_m1 component is a TCP server which accept the connection from m1 and
 The sensor/phicomm_m1 component get the status from server and update homeassistant entity status.
 
 The light/phicomm_m1 component allow user to control the brightness of m1 screen by communicating with server.
-

--- a/custom_components/phicomm_m1/light.py
+++ b/custom_components/phicomm_m1/light.py
@@ -13,7 +13,7 @@ import datetime
 
 
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, Light, SUPPORT_BRIGHTNESS)
+    ATTR_BRIGHTNESS, LightEntity, SUPPORT_BRIGHTNESS)
 
 log = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(devs)
 
 
-class PhicommM1Brightness(Light):
+class PhicommM1Brightness(LightEntity):
     """Representation of an m1 screen brightness."""
 
     def __init__(self, status, icon=None):

--- a/custom_components/phicomm_m1/manifest.json
+++ b/custom_components/phicomm_m1/manifest.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.1.0",
     "domain": "phicomm_m1",
     "name": "Phicomm M1 sensor",
     "documentation": "https://github.com/binss/homeassistant-phicomm-m1",

--- a/custom_components/phicomm_m1/manifest.json
+++ b/custom_components/phicomm_m1/manifest.json
@@ -1,0 +1,8 @@
+{
+    "domain": "phicomm_m1",
+    "name": "Phicomm M1 sensor",
+    "documentation": "https://github.com/binss/homeassistant-phicomm-m1",
+    "dependencies": [],
+    "codeowners": ["@binss", "@nykma"],
+    "requirements": ["tornado==6.0.3"]
+}

--- a/custom_components/phicomm_m1/sensor.py
+++ b/custom_components/phicomm_m1/sensor.py
@@ -12,7 +12,7 @@ import logging
 import datetime
 
 from homeassistant.const import TEMP_CELSIUS
-from homeassistant.components.homekit.const import DEVICE_CLASS_CO2
+from homeassistant.components.homekit.type_sensors import DEVICE_CLASS_CO
 from homeassistant.helpers.entity import Entity
 
 log = logging.getLogger(__name__)
@@ -134,4 +134,4 @@ class PhicommM1Hcho(Entity):
         """Since homeassistant-homekit do not support hcho sensor,
         We set our class to co2 for being showed in homekit.
         """
-        return DEVICE_CLASS_CO2
+        return DEVICE_CLASS_CO


### PR DESCRIPTION
See https://developers.home-assistant.io/docs/en/creating_integration_manifest.html#requirements 

Since 0.92.0, hass can manage the requirements as declared in `manifest.json` .